### PR TITLE
URL Cleanup

### DIFF
--- a/src/reference/docbook/api.xml
+++ b/src/reference/docbook/api.xml
@@ -19,7 +19,7 @@ TripIt tripit = new TripItTemplate(consumerKey, consumerSecret, accessToken, acc
 	</programlisting>
 		
 	<para>
-		If you are using Spring Social's <ulink url="http://static.springsource.org/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>TripIt</interfacename> from a <interfacename>Connection</interfacename>. 
+		If you are using Spring Social's <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html">service provider framework</ulink>, you can get an instance of <interfacename>TripIt</interfacename> from a <interfacename>Connection</interfacename>. 
 		For example, the following snippet calls <methodname>getApi()</methodname> on a connection to retrieve a <interfacename>TripIt</interfacename>:
 	</para>				
 	

--- a/src/reference/docbook/connecting.xml
+++ b/src/reference/docbook/connecting.xml
@@ -63,7 +63,7 @@ public class SocialConfig {
 	</para>	
 		
 	<para>
-		Refer to <ulink url="http://static.springsource.org/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
+		Refer to <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html">Spring Social's reference documentation</ulink> for complete details on configuring <classname>ConnectController</classname> and its dependencies.
 	</para>
 			
 </chapter>

--- a/src/reference/docbook/overview.xml
+++ b/src/reference/docbook/overview.xml
@@ -7,11 +7,11 @@
     <title>Introduction</title>
 
     <para>
-	    The Spring Social TripIt project is an extension to <ulink url="http://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with TripIt.
+	    The Spring Social TripIt project is an extension to <ulink url="https://www.springframework.org/spring-social">Spring Social</ulink> that enables integration with TripIt.
 	</para>
 
 	<para>
-		<ulink url="http://www.tripit.com">TripIt</ulink> is a social network that links together travelers. 
+		<ulink url="https://www.tripit.com">TripIt</ulink> is a social network that links together travelers. 
 		By connecting with other travelers, you can keep in touch with contacts when your travel plans coincide. 
 		Also, aside from its social aspects, TripIt is a rather useful service for managing one's travel information.
 	</para>
@@ -57,7 +57,7 @@
 
 	<para>
 		Spring Social TripIt uses Spring Social's <classname>OAuth1Template</classname> to add OAuth 1.0a authorization headers to requests sent to TripIt.
-		<classname>OAuth1Template</classname> uses the <ulink url="http://commons.apache.org/codec/">Commons Codec</ulink> library when calculating request signatures.
+		<classname>OAuth1Template</classname> uses the <ulink url="https://commons.apache.org/codec/">Commons Codec</ulink> library when calculating request signatures.
 		Therefore, you'll also need Commons Codec in your project:
 	</para>
 
@@ -70,7 +70,7 @@
     </programlisting>
 
 	<para>
-		Consult <ulink url="http://static.springsource.org/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
+		Consult <ulink url="https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html#overview-howtoget">Spring Social's reference documentation</ulink> for more information on Spring Social dependencies.
 	</para>
   </section>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/spring-social (404) with 1 occurrences migrated to:  
  https://www.springframework.org/spring-social ([https](https://www.springframework.org/spring-social) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springsource.org/spring-social/docs/1.0.x/reference/html/connecting.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/connecting.html ([https](https://static.springsource.org/spring-social/docs/1.0.x/reference/html/connecting.html) result 200).
* http://static.springsource.org/spring-social/docs/1.0.x/reference/html/overview.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/overview.html ([https](https://static.springsource.org/spring-social/docs/1.0.x/reference/html/overview.html) result 200).
* http://static.springsource.org/spring-social/docs/1.0.x/reference/html/serviceprovider.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/1.0.x/reference/html/serviceprovider.html ([https](https://static.springsource.org/spring-social/docs/1.0.x/reference/html/serviceprovider.html) result 200).
* http://www.tripit.com with 1 occurrences migrated to:  
  https://www.tripit.com ([https](https://www.tripit.com) result 301).
* http://commons.apache.org/codec/ with 1 occurrences migrated to:  
  https://commons.apache.org/codec/ ([https](https://commons.apache.org/codec/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://www.w3.org/1999/xlink with 4 occurrences
* http://www.w3.org/2001/XInclude with 1 occurrences